### PR TITLE
Issue 2: Development Requester context + reference data

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,21 @@
-import { useState } from "react";
+import React, { useState } from "react";
+import { RequesterProvider, useRequester } from "./context/RequesterContext.js";
+import { AppHeader } from "./components/AppHeader.js";
+import { RequesterSelectionScreen } from "./components/RequesterSelectionScreen.js";
 import { checkHealth, getCategories, Category } from "./api.js";
+import "./index.css";
 
 type UiState = "idle" | "loading" | "success" | "error";
 
-export default function App() {
+function MainContent() {
+  const { selectedRequester } = useRequester();
   const [state, setState] = useState<UiState>("idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [categories, setCategories] = useState<Category[]>([]);
+
+  if (!selectedRequester) {
+    return <RequesterSelectionScreen />;
+  }
 
   async function handleCheck() {
     setState("loading");
@@ -33,7 +42,14 @@ export default function App() {
   }
 
   return (
-    <div className="container py-5" style={{ maxWidth: 640 }}>
+    <div className="container py-4" style={{ maxWidth: 640 }}>
+      <div className="alert alert-success mb-4">
+        <h5 className="alert-heading mb-1">Development Requester Active</h5>
+        <div>
+          Current Requester Context: <strong>{selectedRequester.name}</strong> ({selectedRequester.email})
+        </div>
+      </div>
+
       <h1 className="h3 mb-4">
         TokTickIT <span className="text-success">IT Service Desk</span>
       </h1>
@@ -67,4 +83,19 @@ export default function App() {
     </div>
   );
 }
+
+export default function App() {
+  return (
+    <RequesterProvider>
+      <div className="min-vh-100 d-flex flex-column">
+        <AppHeader />
+        <main className="flex-grow-1">
+          <MainContent />
+        </main>
+      </div>
+    </RequesterProvider>
+  );
+}
+
+
 

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -5,6 +5,17 @@ export interface Category {
   name: string;
 }
 
+export interface RequesterUser {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export interface RelatedSystem {
+  id: number;
+  name: string;
+}
+
 export interface SystemStatus {
   online: boolean;
   categories: Category[];
@@ -47,6 +58,38 @@ export async function getCategories(): Promise<Category[]> {
   return await res.json();
 }
 
+// Issue 2 — Development Requester list
+export async function getRequesters(): Promise<RequesterUser[]> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/api/requesters`);
+  } catch {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+
+  if (!res.ok) {
+    throw new Error("Unable to load requesters");
+  }
+
+  return await res.json();
+}
+
+// Issue 2 — Related Systems list
+export async function getRelatedSystems(): Promise<RelatedSystem[]> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/api/related-systems`);
+  } catch {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+
+  if (!res.ok) {
+    throw new Error("Unable to load related systems");
+  }
+
+  return await res.json();
+}
+
 export async function checkSystem(): Promise<SystemStatus> {
   const health = await checkHealth();
   if (health.status !== "ok") {
@@ -55,3 +98,4 @@ export async function checkSystem(): Promise<SystemStatus> {
   const categories = await getCategories();
   return { online: true, categories };
 }
+

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useRequester } from "../context/RequesterContext.js";
+
+export const AppHeader: React.FC = () => {
+  const { selectedRequester, clearRequester } = useRequester();
+
+  return (
+    <header className="zg-header shadow-sm py-2 px-3">
+      <div className="container-fluid d-flex align-items-center justify-content-between">
+        <div className="d-flex align-items-center gap-3">
+          <span className="h4 mb-0 fw-bold tracking-tight text-white">TokTickIT</span>
+          <span className="badge bg-light text-dark font-weight-normal small">IT Service Desk</span>
+        </div>
+
+        {selectedRequester && (
+          <div className="d-flex align-items-center gap-3">
+            <div className="text-end text-white">
+              <div className="small opacity-75">Selected Requester</div>
+              <div className="fw-semibold text-truncate" style={{ maxWidth: 200 }}>
+                {selectedRequester.name}
+              </div>
+            </div>
+            <button
+              onClick={clearRequester}
+              className="btn btn-sm btn-outline-light"
+              aria-label="Change Requester"
+            >
+              Change Requester
+            </button>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+};

--- a/client/src/components/RequesterSelectionScreen.tsx
+++ b/client/src/components/RequesterSelectionScreen.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from "react";
+import { getRequesters, RequesterUser } from "../api.js";
+import { useRequester } from "../context/RequesterContext.js";
+
+type UiState = "loading" | "success" | "error" | "empty";
+
+export const RequesterSelectionScreen: React.FC = () => {
+  const { setSelectedRequester } = useRequester();
+  const [requesters, setRequesters] = useState<RequesterUser[]>([]);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [state, setState] = useState<UiState>("loading");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const loadRequesters = async () => {
+    setState("loading");
+    setErrorMessage("");
+    try {
+      const data = await getRequesters();
+      if (!data || data.length === 0) {
+        setRequesters([]);
+        setState("empty");
+      } else {
+        setRequesters(data);
+        setSelectedId(data[0].id.toString());
+        setState("success");
+      }
+    } catch (err: unknown) {
+      setState("error");
+      if (err instanceof Error) {
+        setErrorMessage(err.message);
+      } else {
+        setErrorMessage("Unable to load requesters");
+      }
+    }
+  };
+
+  useEffect(() => {
+    loadRequesters();
+  }, []);
+
+  const handleContinue = (e: React.FormEvent) => {
+    e.preventDefault();
+    const req = requesters.find((r) => r.id.toString() === selectedId);
+    if (req) {
+      setSelectedRequester(req);
+    }
+  };
+
+  return (
+    <div className="container py-5 d-flex justify-content-center">
+      <div className="zg-card p-4 w-100" style={{ maxWidth: 480 }}>
+        <div className="text-center mb-3">
+          <div className="display-6 mb-2">👤</div>
+          <h1 className="h4 font-weight-bold mb-2">Select Development Requester</h1>
+          <p className="text-muted small">
+            This is a temporary development testing mechanism to simulate being logged in as a specific Requester.
+          </p>
+        </div>
+
+        {state === "loading" && (
+          <div>
+            <div className="mb-3">
+              <label htmlFor="requesterSelect" className="form-label fw-medium">
+                Development Requester
+              </label>
+              <select id="requesterSelect" className="form-select" disabled>
+                <option>Loading requesters...</option>
+              </select>
+            </div>
+            <button className="btn zg-btn-primary w-100 py-2" disabled>
+              Continue
+            </button>
+          </div>
+        )}
+
+        {state === "error" && (
+          <div className="alert alert-danger" role="alert">
+            <div className="fw-bold mb-1">Error Loading Requesters</div>
+            <div className="small mb-3">{errorMessage || "Unable to load requesters"}</div>
+            <button className="btn btn-outline-danger btn-sm w-100" onClick={loadRequesters}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {state === "empty" && (
+          <div className="alert alert-warning text-center" role="status">
+            <div className="fw-bold mb-1">No Active Requesters Found</div>
+            <div className="small mb-3">
+              Please check your seed data or database connection to populate active Development Requesters.
+            </div>
+            <button className="btn btn-outline-secondary btn-sm" onClick={loadRequesters}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {state === "success" && (
+          <form onSubmit={handleContinue}>
+            <div className="mb-3">
+              <label htmlFor="requesterSelect" className="form-label fw-medium">
+                Development Requester <span className="text-danger">*</span>
+              </label>
+              <select
+                id="requesterSelect"
+                className="form-select"
+                value={selectedId}
+                onChange={(e) => setSelectedId(e.target.value)}
+                required
+              >
+                {requesters.map((req) => (
+                  <option key={req.id} value={req.id}>
+                    {req.name} ({req.email})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="zg-callout-info small mb-3">
+              ℹ️ Only active development requesters are shown in this list.
+            </div>
+
+            <button type="submit" className="btn zg-btn-primary w-100 py-2 font-weight-bold">
+              Continue
+            </button>
+
+            <div className="text-center mt-3 text-muted small">
+              Note: Real authentication will be introduced in Lab 3.
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/client/src/context/RequesterContext.tsx
+++ b/client/src/context/RequesterContext.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+import { RequesterUser } from "../api.js";
+
+interface RequesterContextType {
+  selectedRequester: RequesterUser | null;
+  setSelectedRequester: (requester: RequesterUser | null) => void;
+  clearRequester: () => void;
+}
+
+const STORAGE_KEY = "toktickit_selected_requester";
+
+const RequesterContext = createContext<RequesterContextType | undefined>(undefined);
+
+export const RequesterProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [selectedRequester, setSelectedRequesterState] = useState<RequesterUser | null>(() => {
+    try {
+      const stored = sessionStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const setSelectedRequester = (requester: RequesterUser | null) => {
+    setSelectedRequesterState(requester);
+    try {
+      if (requester) {
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(requester));
+      } else {
+        sessionStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      // Ignore storage write errors
+    }
+  };
+
+  const clearRequester = () => {
+    setSelectedRequester(null);
+  };
+
+  return (
+    <RequesterContext.Provider value={{ selectedRequester, setSelectedRequester, clearRequester }}>
+      {children}
+    </RequesterContext.Provider>
+  );
+};
+
+export const useRequester = (): RequesterContextType => {
+  const context = useContext(RequesterContext);
+  if (!context) {
+    throw new Error("useRequester must be used within a RequesterProvider");
+  }
+  return context;
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,76 @@
+:root {
+  --zg-primary: #006B3C;
+  --zg-secondary: #0B7A46;
+  --zg-pale: #EAF6EF;
+  --zg-bg: #F5F7F6;
+  --zg-surface: #FFFFFF;
+  --zg-text: #1F2A24;
+  --zg-field-editable-bg: #FFFFFF;
+  --zg-field-readonly-bg: #F1EFE6;
+  --zg-error: #8A1F1F;
+  --zg-error-border: #C0392B;
+  --zg-warning: #B8860B;
+  --zg-success: #0B7A46;
+}
+
+body {
+  background-color: var(--zg-bg);
+  color: var(--zg-text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0;
+}
+
+.zg-header {
+  background-color: var(--zg-primary);
+  color: #ffffff;
+}
+
+.zg-header a {
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.zg-card {
+  background-color: var(--zg-surface);
+  border: 1px solid #E0E7E3;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.zg-btn-primary {
+  background-color: var(--zg-primary);
+  color: #ffffff;
+  border: none;
+}
+
+.zg-btn-primary:hover, .zg-btn-primary:focus {
+  background-color: var(--zg-secondary);
+  color: #ffffff;
+}
+
+.zg-btn-primary:disabled {
+  background-color: #D8DDD9;
+  color: #6C757D;
+}
+
+.zg-btn-secondary {
+  background-color: #ffffff;
+  color: var(--zg-secondary);
+  border: 1px solid var(--zg-secondary);
+}
+
+.zg-btn-secondary:hover {
+  background-color: var(--zg-pale);
+  color: var(--zg-primary);
+}
+
+.zg-callout-info {
+  background-color: var(--zg-pale);
+  border-left: 4px solid var(--zg-secondary);
+  color: var(--zg-text);
+  padding: 12px 16px;
+  border-radius: 4px;
+}

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,13 +1,28 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
 import App from "../../src/App.js";
 import * as api from "../../src/api.js";
 
 describe("App", () => {
+  const mockRequester = {
+    id: 1,
+    name: "Jennifer Anderson",
+    email: "jennifer.anderson@example.com",
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+    sessionStorage.setItem("toktickit_selected_requester", JSON.stringify(mockRequester));
+    vi.spyOn(api, "getRequesters").mockResolvedValue([mockRequester]);
+  });
+
   it("renders the TokTickIT heading", () => {
     render(<App />);
-    expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/TokTickIT/i).length).toBeGreaterThan(0);
   });
+
 
   it("shows loading state and System Status: Online when health check succeeds", async () => {
     vi.spyOn(api, "checkHealth").mockResolvedValue({ status: "ok", service: "TokTickIT API" });
@@ -61,3 +76,5 @@ describe("App", () => {
     });
   });
 });
+
+

--- a/client/tests/lab-02/requester-selection.test.tsx
+++ b/client/tests/lab-02/requester-selection.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import App from "../../src/App.js";
+import { RequesterSelectionScreen } from "../../src/components/RequesterSelectionScreen.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import * as api from "../../src/api.js";
+
+describe("RequesterSelectionScreen and Context (UI-01, UI-02)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("UI-01: loads active Requesters only into the dropdown and excludes inactive requesters", async () => {
+    const mockRequesters: api.RequesterUser[] = [
+      { id: 1, name: "Jennifer Anderson", email: "jennifer.anderson@example.com" },
+      { id: 2, name: "Michael Brown", email: "michael.brown@example.com" },
+    ];
+
+    vi.spyOn(api, "getRequesters").mockResolvedValue(mockRequesters);
+
+    render(
+      <RequesterProvider>
+        <RequesterSelectionScreen />
+      </RequesterProvider>
+    );
+
+    expect(screen.getByText(/Loading requesters.../i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Jennifer Anderson/i })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: /Michael Brown/i })).toBeInTheDocument();
+    });
+
+    // Inactive Requester must not be present in options
+    expect(screen.queryByText(/Inactive Tester/i)).not.toBeInTheDocument();
+  });
+
+  it("UI-02: shows Requester Selection screen when no Requester is selected", async () => {
+    vi.spyOn(api, "getRequesters").mockResolvedValue([
+      { id: 1, name: "Jennifer Anderson", email: "jennifer.anderson@example.com" },
+    ]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Select Development Requester/i)).toBeInTheDocument();
+    });
+  });
+
+  it("allows selecting a requester, saving context, and changing requester", async () => {
+    const mockRequesters: api.RequesterUser[] = [
+      { id: 1, name: "Jennifer Anderson", email: "jennifer.anderson@example.com" },
+      { id: 2, name: "Michael Brown", email: "michael.brown@example.com" },
+    ];
+
+    vi.spyOn(api, "getRequesters").mockResolvedValue(mockRequesters);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Jennifer Anderson/i })).toBeInTheDocument();
+    });
+
+    const select = screen.getByLabelText(/Development Requester/i);
+    fireEvent.change(select, { target: { value: "2" } });
+
+    const continueButton = screen.getByRole("button", { name: /Continue/i });
+    fireEvent.click(continueButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Current Requester Context:/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/Michael Brown/i).length).toBeGreaterThan(0);
+    });
+
+
+    // Header should show Change Requester button
+    const changeButton = screen.getByRole("button", { name: /Change Requester/i });
+    expect(changeButton).toBeInTheDocument();
+
+    // Clicking Change Requester should redirect back to selection screen
+    fireEvent.click(changeButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Select Development Requester/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/server/prisma/migrations/20260904080755_add_requester_and_related_system/migration.sql
+++ b/server/prisma/migrations/20260904080755_add_requester_and_related_system/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "RequesterUser" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");

--- a/server/prisma/migrations/20260904205408_add_is_active_to_category/migration.sql
+++ b/server/prisma/migrations/20260904205408_add_is_active_to_category/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,3 +20,22 @@ model Category {
   createdAt DateTime @default(now())
 }
 
+// ---------------------------------------------------------------------------
+// Lab 2 Issue 2 — RequesterUser and RelatedSystem
+// ---------------------------------------------------------------------------
+
+model RequesterUser {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+}
+
+model RelatedSystem {
+  id       Int     @id @default(autoincrement())
+  name     String  @unique
+  isActive Boolean @default(true)
+}
+
+

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -17,8 +17,10 @@ datasource db {
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
 }
+
 
 // ---------------------------------------------------------------------------
 // Lab 2 Issue 2 — RequesterUser and RelatedSystem

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -21,7 +21,41 @@ async function main() {
     });
   }
 
-  console.log("Seeding categories completed successfully.");
+  const requesters = [
+    { name: "Jennifer Anderson", email: "jennifer.anderson@example.com", isActive: true },
+    { name: "Michael Brown", email: "michael.brown@example.com", isActive: true },
+    { name: "Sarah Connor", email: "sarah.connor@example.com", isActive: true },
+    { name: "David Miller", email: "david.miller@example.com", isActive: true },
+    { name: "Inactive Tester", email: "inactive.tester@example.com", isActive: false },
+  ];
+
+  for (const req of requesters) {
+    await prisma.requesterUser.upsert({
+      where: { email: req.email },
+      update: { name: req.name, isActive: req.isActive },
+      create: req,
+    });
+  }
+
+  const relatedSystems = [
+    "Email",
+    "Campus Wi-Fi",
+    "VPN",
+    "LEB2 App",
+    "Grade Submission App",
+    "Printer",
+    "Corporate Laptop",
+  ];
+
+  for (const name of relatedSystems) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+
+  console.log("Seeding categories, requesters, and related systems completed successfully.");
 }
 
 main()
@@ -32,3 +66,4 @@ main()
   .finally(async () => {
     await getPrisma().$disconnect();
   });
+

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,6 +32,9 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
   try {
     const prisma = getPrisma();
     const categories = await prisma.category.findMany({
+      where: {
+        isActive: true,
+      },
       select: {
         id: true,
         name: true,
@@ -45,6 +48,7 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
     res.status(500).json({ error: "Failed to fetch categories" });
   }
 });
+
 
 // ---------------------------------------------------------------------------
 // Lab 2 Issue 2 — Development Requester list

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -46,4 +46,56 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Lab 2 Issue 2 — Development Requester list
+// GET /api/requesters -> returns active RequesterUser records only (BR-06)
+// ---------------------------------------------------------------------------
+app.get("/api/requesters", async (_req: Request, res: Response) => {
+  try {
+    const prisma = getPrisma();
+    const requesters = await prisma.requesterUser.findMany({
+      where: {
+        isActive: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+    res.status(200).json(requesters);
+  } catch (error) {
+    res.status(500).json({ error: "Unable to load requesters" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Lab 2 Issue 2 — Related Systems list
+// GET /api/related-systems -> returns active RelatedSystem records only
+// ---------------------------------------------------------------------------
+app.get("/api/related-systems", async (_req: Request, res: Response) => {
+  try {
+    const prisma = getPrisma();
+    const systems = await prisma.relatedSystem.findMany({
+      where: {
+        isActive: true,
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+    res.status(200).json(systems);
+  } catch (error) {
+    res.status(500).json({ error: "Unable to load related systems" });
+  }
+});
+
 export default app;
+

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
 
 describe("GET /api/categories", () => {
   it("returns the four seeded categories in id order", async () => {
@@ -13,5 +14,31 @@ describe("GET /api/categories", () => {
       { id: 4, name: "Network" },
     ]);
   });
+
+  it("excludes inactive categories from results", async () => {
+    const prisma = getPrisma();
+    const inactiveCategory = await prisma.category.create({
+      data: {
+        name: "Legacy System (Deprecated)",
+        isActive: false,
+      },
+    });
+
+    try {
+      const res = await request(app).get("/api/categories");
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+
+      const foundInactive = res.body.some(
+        (cat: { name: string }) => cat.name === "Legacy System (Deprecated)"
+      );
+      expect(foundInactive).toBe(false);
+    } finally {
+      await prisma.category.delete({
+        where: { id: inactiveCategory.id },
+      });
+    }
+  });
 });
+
 

--- a/server/tests/lab-02/requesters.api.test.ts
+++ b/server/tests/lab-02/requesters.api.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+describe("GET /api/requesters (API-16)", () => {
+  it("returns active requesters only and excludes inactive requesters", async () => {
+    const res = await request(app).get("/api/requesters");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(4);
+
+    // Each object must have id, name, email
+    for (const req of res.body) {
+      expect(req).toHaveProperty("id");
+      expect(req).toHaveProperty("name");
+      expect(req).toHaveProperty("email");
+      expect(req).not.toHaveProperty("isActive");
+    }
+
+    // Inactive requester must NOT be included (BR-06, AC-12, API-16)
+    const inactiveFound = res.body.some(
+      (req: { name: string; email: string }) =>
+        req.name === "Inactive Tester" || req.email === "inactive.tester@example.com"
+    );
+    expect(inactiveFound).toBe(false);
+  });
+});
+
+describe("GET /api/related-systems", () => {
+  it("returns active related systems", async () => {
+    const res = await request(app).get("/api/related-systems");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(6);
+
+    for (const sys of res.body) {
+      expect(sys).toHaveProperty("id");
+      expect(sys).toHaveProperty("name");
+      expect(sys).not.toHaveProperty("isActive");
+    }
+  });
+});


### PR DESCRIPTION
Implement the temporary Lab 2 RequesterUser model and the Development Requester Selection screen, plus the Category/RelatedSystem reference data needed for ticket creation. This is a testing mechanism only — no passwords, sessions, or real authentication.

Acceptance Criteria
 RequesterUser Prisma model created (id, name, email unique, isActive, createdAt).
 RelatedSystem Prisma model created (id, name unique, isActive).
 Idempotent seed: at least 4 active Development Requesters, at least 1 inactive; at least 6 realistic Related Systems; 4 required Categories confirmed present.
 GET /api/requesters returns only active Requesters.
 GET /api/related-systems and GET /api/categories return only active records.
 Development Requester Selection screen built per ui-spec.md (dropdown, Continue button, loading/empty/error states).
 Selected Requester stored as session/app context; name displayed in app shell; "Change Requester" action available and functional.
 BR-05, BR-06, BR-07, BR-08 covered by tests.
 Unit + API tests pass for this Issue's scope.