### PR TITLE
Issue 5: Requester Ticket Detail + Attachments

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,33 +4,69 @@ import { AppHeader } from "./components/AppHeader.js";
 import { RequesterSelectionScreen } from "./components/RequesterSelectionScreen.js";
 import { CreateTicketScreen } from "./components/CreateTicketScreen.js";
 import { MyTicketsScreen } from "./components/MyTicketsScreen.js";
+import { RequesterTicketDetailScreen } from "./components/RequesterTicketDetailScreen.js";
 import "./index.css";
 
 type Tab = "my-tickets" | "create-ticket";
 
-function MainContent({ activeTab, onSelectTab }: { activeTab: Tab; onSelectTab: (tab: Tab) => void }) {
+function MainContent({
+  activeTab,
+  onSelectTab,
+  selectedTicketId,
+  onSelectTicket,
+}: {
+  activeTab: Tab;
+  onSelectTab: (tab: Tab) => void;
+  selectedTicketId: number | null;
+  onSelectTicket: (id: number | null) => void;
+}) {
   const { selectedRequester } = useRequester();
 
   if (!selectedRequester) {
     return <RequesterSelectionScreen />;
   }
 
+  if (selectedTicketId !== null) {
+    return (
+      <RequesterTicketDetailScreen
+        ticketId={selectedTicketId}
+        onBack={() => onSelectTicket(null)}
+      />
+    );
+  }
+
   if (activeTab === "create-ticket") {
     return <CreateTicketScreen />;
   }
 
-  return <MyTicketsScreen onNavigateToCreate={() => onSelectTab("create-ticket")} />;
+  return (
+    <MyTicketsScreen
+      onNavigateToCreate={() => onSelectTab("create-ticket")}
+      onSelectTicket={(id) => onSelectTicket(id)}
+    />
+  );
 }
 
 export default function App() {
   const [activeTab, setActiveTab] = useState<Tab>("my-tickets");
+  const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
+
+  const handleSelectTab = (tab: Tab) => {
+    setSelectedTicketId(null);
+    setActiveTab(tab);
+  };
 
   return (
     <RequesterProvider>
       <div className="min-vh-100 d-flex flex-column">
-        <AppHeader activeTab={activeTab} onSelectTab={setActiveTab} />
+        <AppHeader activeTab={activeTab} onSelectTab={handleSelectTab} />
         <main className="flex-grow-1">
-          <MainContent activeTab={activeTab} onSelectTab={setActiveTab} />
+          <MainContent
+            activeTab={activeTab}
+            onSelectTab={handleSelectTab}
+            selectedTicketId={selectedTicketId}
+            onSelectTicket={setSelectedTicketId}
+          />
         </main>
       </div>
     </RequesterProvider>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -223,5 +223,139 @@ export async function getTickets(
   return await res.json();
 }
 
+// Issue 5 — Requester Ticket Detail & Attachments interfaces
+export interface AttachmentItem {
+  id: number;
+  fileName: string;
+  sizeBytes: number;
+  uploadedAt: string;
+  removedAt: string | null;
+  removedReason: string | null;
+}
+
+export interface TicketDetail {
+  id: number;
+  ticketNumber: string;
+  requesterId: number;
+  categoryName: string;
+  relatedSystemName: string;
+  summary: string;
+  description: string;
+  requestedPriority: "LOW" | "MEDIUM" | "HIGH";
+  itPriority: "LOW" | "MEDIUM" | "HIGH" | null;
+  currentStatus: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Issue 5 — Get single ticket detail
+export async function getTicket(id: number, requesterId: number): Promise<TicketDetail> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/api/tickets/${id}`, {
+      headers: {
+        "X-Requester-Id": requesterId.toString(),
+      },
+    });
+  } catch {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error("Ticket not found");
+    }
+    throw new Error("Unable to load ticket detail");
+  }
+
+  return await res.json();
+}
+
+// Issue 5 — Get attachments list for ticket
+export async function getAttachments(ticketId: number, requesterId: number): Promise<AttachmentItem[]> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+      headers: {
+        "X-Requester-Id": requesterId.toString(),
+      },
+    });
+  } catch {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error("Ticket not found");
+    }
+    throw new Error("Unable to load attachments");
+  }
+
+  return await res.json();
+}
+
+// Issue 5 — Upload attachment
+export async function uploadAttachment(
+  ticketId: number,
+  file: File,
+  requesterId: number
+): Promise<AttachmentItem> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+      method: "POST",
+      headers: {
+        "X-Requester-Id": requesterId.toString(),
+      },
+      body: formData,
+    });
+  } catch {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error ?? "Unable to upload attachment");
+  }
+
+  return data;
+}
+
+// Issue 5 — Download attachment helper function
+export function downloadAttachmentUrl(attachmentId: number): string {
+  return `${API_URL}/api/attachments/${attachmentId}/download`;
+}
+
+// Issue 5 — Soft-remove attachment
+export async function deleteAttachment(
+  attachmentId: number,
+  reason: string,
+  requesterId: number
+): Promise<{ id: number; fileName: string; removedAt: string; removedReason: string }> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/api/attachments/${attachmentId}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Requester-Id": requesterId.toString(),
+      },
+      body: JSON.stringify({ reason }),
+    });
+  } catch {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error ?? "Unable to remove attachment");
+  }
+
+  return data;
+}
+
 
 

--- a/client/src/components/MyTicketsScreen.tsx
+++ b/client/src/components/MyTicketsScreen.tsx
@@ -10,9 +10,13 @@ import { useRequester } from "../context/RequesterContext.js";
 
 interface MyTicketsScreenProps {
   onNavigateToCreate: () => void;
+  onSelectTicket?: (id: number) => void;
 }
 
-export const MyTicketsScreen: React.FC<MyTicketsScreenProps> = ({ onNavigateToCreate }) => {
+export const MyTicketsScreen: React.FC<MyTicketsScreenProps> = ({
+  onNavigateToCreate,
+  onSelectTicket,
+}) => {
   const { selectedRequester } = useRequester();
 
   const [categories, setCategories] = useState<Category[]>([]);
@@ -366,7 +370,11 @@ export const MyTicketsScreen: React.FC<MyTicketsScreenProps> = ({ onNavigateToCr
               </thead>
               <tbody>
                 {tickets.map((t) => (
-                  <tr key={t.id}>
+                  <tr
+                    key={t.id}
+                    onClick={() => onSelectTicket?.(t.id)}
+                    style={{ cursor: onSelectTicket ? "pointer" : "default" }}
+                  >
                     <td className="font-monospace fw-bold text-success">{t.ticketNumber}</td>
                     <td className="small text-muted">
                       {new Date(t.createdAt).toLocaleDateString("en-US", {
@@ -389,7 +397,12 @@ export const MyTicketsScreen: React.FC<MyTicketsScreenProps> = ({ onNavigateToCr
           {/* Mobile Card List View (d-md-none) */}
           <div className="d-md-none d-flex flex-column gap-3 mb-4">
             {tickets.map((t) => (
-              <div key={t.id} className="zg-card p-3">
+              <div
+                key={t.id}
+                className="zg-card p-3"
+                onClick={() => onSelectTicket?.(t.id)}
+                style={{ cursor: onSelectTicket ? "pointer" : "default" }}
+              >
                 <div className="d-flex justify-content-between align-items-start mb-2">
                   <span className="font-monospace fw-bold text-success">{t.ticketNumber}</span>
                   {renderStatusBadge(t.currentStatus)}

--- a/client/src/components/RequesterTicketDetailScreen.tsx
+++ b/client/src/components/RequesterTicketDetailScreen.tsx
@@ -1,0 +1,470 @@
+import React, { useEffect, useState } from "react";
+import {
+  getTicket,
+  getAttachments,
+  uploadAttachment,
+  deleteAttachment,
+  downloadAttachmentUrl,
+  TicketDetail,
+  AttachmentItem,
+} from "../api.js";
+import { useRequester } from "../context/RequesterContext.js";
+
+interface RequesterTicketDetailScreenProps {
+  ticketId: number;
+  onBack: () => void;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(isoStr: string): string {
+  try {
+    const d = new Date(isoStr);
+    return d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return isoStr;
+  }
+}
+
+export const RequesterTicketDetailScreen: React.FC<RequesterTicketDetailScreenProps> = ({
+  ticketId,
+  onBack,
+}) => {
+  const { selectedRequester } = useRequester();
+
+  const [ticket, setTicket] = useState<TicketDetail | null>(null);
+  const [attachments, setAttachments] = useState<AttachmentItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>("");
+
+  // Upload state & message
+  const [uploading, setUploading] = useState<boolean>(false);
+  const [uploadError, setUploadError] = useState<string>("");
+  const [uploadSuccess, setUploadSuccess] = useState<string>("");
+
+  // Soft-remove modal state
+  const [removeTarget, setRemoveTarget] = useState<AttachmentItem | null>(null);
+  const [removeReason, setRemoveReason] = useState<string>("");
+  const [removeReasonError, setRemoveReasonError] = useState<string>("");
+  const [removing, setRemoving] = useState<boolean>(false);
+
+  const fetchTicketData = async () => {
+    if (!selectedRequester) return;
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const [ticketData, attachmentData] = await Promise.all([
+        getTicket(ticketId, selectedRequester.id),
+        getAttachments(ticketId, selectedRequester.id),
+      ]);
+      setTicket(ticketData);
+      setAttachments(attachmentData);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Unable to load ticket details");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTicketData();
+  }, [ticketId, selectedRequester]);
+
+  const activeAttachments = attachments.filter((att) => att.removedAt === null);
+  const removedAttachments = attachments.filter((att) => att.removedAt !== null);
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !selectedRequester) return;
+
+    setUploadError("");
+    setUploadSuccess("");
+
+    // Client-side Validation (BR-21, BR-22, BR-23)
+    const allowedTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"];
+    const ext = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
+    const allowedExts = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+
+    if (!allowedTypes.includes(file.type) && !allowedExts.includes(ext)) {
+      setUploadError("Only JPG, PNG, WEBP, and PDF files are allowed");
+      e.target.value = "";
+      return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      setUploadError("File exceeds the 5 MB limit");
+      e.target.value = "";
+      return;
+    }
+
+    if (activeAttachments.length >= 5) {
+      setUploadError("A ticket may have at most 5 active attachments");
+      e.target.value = "";
+      return;
+    }
+
+    setUploading(true);
+
+    try {
+      const newAtt = await uploadAttachment(ticketId, file, selectedRequester.id);
+      setAttachments((prev) => [...prev, newAtt]);
+      setUploadSuccess(`Attachment "${newAtt.fileName}" uploaded successfully.`);
+      e.target.value = "";
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setUploadError(err.message);
+      } else {
+        setUploadError("Failed to upload attachment");
+      }
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleOpenRemoveModal = (att: AttachmentItem) => {
+    setRemoveTarget(att);
+    setRemoveReason("");
+    setRemoveReasonError("");
+  };
+
+  const handleConfirmRemove = async () => {
+    if (!removeTarget || !selectedRequester) return;
+
+    if (!removeReason.trim()) {
+      setRemoveReasonError("A removal reason is required");
+      return;
+    }
+
+    setRemoving(true);
+    setRemoveReasonError("");
+
+    try {
+      const updated = await deleteAttachment(removeTarget.id, removeReason.trim(), selectedRequester.id);
+      setAttachments((prev) =>
+        prev.map((att) =>
+          att.id === updated.id
+            ? { ...att, removedAt: updated.removedAt, removedReason: updated.removedReason }
+            : att
+        )
+      );
+      setRemoveTarget(null);
+      setRemoveReason("");
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setRemoveReasonError(err.message);
+      } else {
+        setRemoveReasonError("Unable to remove attachment");
+      }
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="container py-4 text-center">
+        <div className="spinner-border text-success my-5" role="status">
+          <span className="visually-hidden">Loading ticket details...</span>
+        </div>
+        <p className="text-muted small">Loading ticket details...</p>
+      </div>
+    );
+  }
+
+  if (error || !ticket) {
+    return (
+      <div className="container py-4">
+        <button className="btn btn-outline-secondary btn-sm mb-3" onClick={onBack}>
+          ← Back to My Tickets
+        </button>
+        <div className="alert alert-danger text-center my-4" role="alert">
+          <div className="fw-bold mb-1">Ticket Not Found</div>
+          <div className="small mb-3">{error || "Ticket not found"}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container py-4">
+      {/* Header Controls */}
+      <div className="d-flex align-items-center justify-content-between mb-4">
+        <button className="btn btn-outline-secondary btn-sm" onClick={onBack}>
+          ← Back to My Tickets
+        </button>
+        <div className="small text-muted font-monospace">{ticket.ticketNumber}</div>
+      </div>
+
+      {/* Read-only Header Card (BR-30) */}
+      <div className="zg-card p-4 mb-4">
+        <div className="border-bottom pb-3 mb-4 d-flex justify-content-between align-items-start flex-wrap gap-2">
+          <div>
+            <h1 className="h4 font-weight-bold mb-1 text-dark">{ticket.summary}</h1>
+            <div className="small text-muted">Created on {formatDate(ticket.createdAt)}</div>
+          </div>
+          <div className="d-flex align-items-center gap-2">
+            <span
+              className="badge px-3 py-2"
+              style={{ backgroundColor: "var(--zg-pale)", color: "var(--zg-secondary)" }}
+            >
+              ● {ticket.currentStatus}
+            </span>
+          </div>
+        </div>
+
+        {/* Read-only Header Grid */}
+        <div className="row g-3 mb-4">
+          <div className="col-12 col-sm-6 col-md-3">
+            <div className="small text-muted mb-1">Ticket Number</div>
+            <div className="fw-bold font-monospace text-success">{ticket.ticketNumber}</div>
+          </div>
+          <div className="col-12 col-sm-6 col-md-3">
+            <div className="small text-muted mb-1">Category</div>
+            <div className="fw-medium">{ticket.categoryName}</div>
+          </div>
+          <div className="col-12 col-sm-6 col-md-3">
+            <div className="small text-muted mb-1">Related System</div>
+            <div className="fw-medium">{ticket.relatedSystemName}</div>
+          </div>
+          <div className="col-12 col-sm-6 col-md-3">
+            <div className="small text-muted mb-1">Requester</div>
+            <div className="fw-medium">{selectedRequester?.name}</div>
+          </div>
+
+          <div className="col-12 col-sm-6 col-md-3">
+            <div className="small text-muted mb-1">Requested Priority</div>
+            <div>
+              {ticket.requestedPriority === "HIGH" && (
+                <span className="badge bg-danger text-white">🔴 High</span>
+              )}
+              {ticket.requestedPriority === "MEDIUM" && (
+                <span className="badge bg-warning text-dark">🟡 Medium</span>
+              )}
+              {ticket.requestedPriority === "LOW" && (
+                <span className="badge bg-secondary text-white">🟢 Low</span>
+              )}
+            </div>
+          </div>
+
+          <div className="col-12 col-sm-6 col-md-3">
+            <div className="small text-muted mb-1">IT Priority</div>
+            <div>
+              {ticket.itPriority === "HIGH" && <span className="badge bg-danger">🔴 High</span>}
+              {ticket.itPriority === "MEDIUM" && (
+                <span className="badge bg-warning text-dark">🟡 Medium</span>
+              )}
+              {ticket.itPriority === "LOW" && <span className="badge bg-secondary">🟢 Low</span>}
+              {!ticket.itPriority && (
+                <span className="badge bg-light text-muted border opacity-75">
+                  Not yet assigned
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Read-only Description */}
+        <div>
+          <div className="small text-muted mb-1">Description</div>
+          <div
+            className="p-3 rounded bg-light border text-break"
+            style={{ whiteSpace: "pre-wrap", fontSize: "0.95rem" }}
+          >
+            {ticket.description}
+          </div>
+        </div>
+      </div>
+
+      {/* Attachments Section */}
+      <div className="zg-card p-4">
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h2 className="h5 font-weight-bold mb-0">Attachments ({activeAttachments.length}/5 active)</h2>
+
+          {/* Add Attachment Control */}
+          <label
+            className={`btn btn-sm zg-btn-primary ${
+              activeAttachments.length >= 5 || uploading ? "disabled" : ""
+            }`}
+            style={{ cursor: activeAttachments.length >= 5 || uploading ? "not-allowed" : "pointer" }}
+          >
+            {uploading ? "Uploading..." : "+ Add Attachment"}
+            <input
+              type="file"
+              className="d-none"
+              onChange={handleFileSelect}
+              disabled={activeAttachments.length >= 5 || uploading}
+              accept=".jpg,.jpeg,.png,.webp,.pdf,image/jpeg,image/png,image/webp,application/pdf"
+              aria-label="Upload Attachment"
+            />
+          </label>
+        </div>
+
+        <p className="small text-muted mb-3">
+          Allowed formats: JPG, PNG, WEBP, PDF (max 5 MB per file, max 5 active attachments).
+        </p>
+
+        {uploadError && (
+          <div className="alert alert-danger alert-dismissible py-2 mb-3" role="alert">
+            <div className="small">{uploadError}</div>
+          </div>
+        )}
+
+        {uploadSuccess && (
+          <div className="alert alert-success alert-dismissible py-2 mb-3" role="alert">
+            <div className="small">{uploadSuccess}</div>
+          </div>
+        )}
+
+        {/* Attachments List */}
+        {attachments.length === 0 ? (
+          <div className="text-center text-muted p-4 border rounded bg-light small">
+            No attachments added yet.
+          </div>
+        ) : (
+          <div className="d-flex flex-column gap-2">
+            {attachments.map((att) => {
+              const isRemoved = att.removedAt !== null;
+
+              return (
+                <div
+                  key={att.id}
+                  className={`p-3 border rounded d-flex align-items-center justify-content-between flex-wrap gap-2 ${
+                    isRemoved ? "bg-light text-muted opacity-75" : "bg-white"
+                  }`}
+                >
+                  <div className="d-flex align-items-center gap-3">
+                    <span className="fs-4">{isRemoved ? "📄" : "📎"}</span>
+                    <div>
+                      <div className={`fw-medium ${isRemoved ? "text-decoration-line-through" : ""}`}>
+                        {att.fileName}
+                      </div>
+                      <div className="small text-muted">
+                        {formatFileSize(att.sizeBytes)} • Uploaded {formatDate(att.uploadedAt)}
+                        {isRemoved && (
+                          <span className="text-danger ms-2">
+                            [Removed {formatDate(att.removedAt!)} — Reason: {att.removedReason}]
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="d-flex align-items-center gap-2">
+                    {!isRemoved ? (
+                      <>
+                        <a
+                          href={downloadAttachmentUrl(att.id)}
+                          target="_blank"
+                          rel="noreferrer"
+                          download={att.fileName}
+                          className="btn btn-outline-primary btn-sm px-3"
+                          aria-label={`Download ${att.fileName}`}
+                        >
+                          Download
+                        </a>
+                        <button
+                          className="btn btn-outline-danger btn-sm px-3"
+                          onClick={() => handleOpenRemoveModal(att)}
+                          aria-label={`Remove ${att.fileName}`}
+                        >
+                          Remove
+                        </button>
+                      </>
+                    ) : (
+                      <span className="badge bg-secondary opacity-75">Removed</span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Soft-Remove Confirmation Modal */}
+      {removeTarget && (
+        <div
+          className="modal fade show d-block"
+          tabIndex={-1}
+          style={{ backgroundColor: "rgba(0,0,0,0.5)" }}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="modal-dialog modal-dialog-centered">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title h6">Remove Attachment</h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={() => setRemoveTarget(null)}
+                  disabled={removing}
+                  aria-label="Close"
+                ></button>
+              </div>
+
+              <div className="modal-body">
+                <p className="small mb-3">
+                  Are you sure you want to remove <strong>{removeTarget.fileName}</strong>? The file will remain visible as removed metadata, but will no longer be downloadable.
+                </p>
+
+                <div className="mb-3">
+                  <label htmlFor="removeReasonInput" className="form-label small fw-bold">
+                    Removal Reason <span className="text-danger">*</span>
+                  </label>
+                  <textarea
+                    id="removeReasonInput"
+                    className={`form-control form-control-sm ${removeReasonError ? "is-invalid" : ""}`}
+                    rows={3}
+                    placeholder="Enter reason for removing this attachment..."
+                    value={removeReason}
+                    onChange={(e) => setRemoveReason(e.target.value)}
+                    disabled={removing}
+                  ></textarea>
+                  {removeReasonError && (
+                    <div className="invalid-feedback small">{removeReasonError}</div>
+                  )}
+                </div>
+              </div>
+
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-secondary"
+                  onClick={() => setRemoveTarget(null)}
+                  disabled={removing}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-danger px-3"
+                  onClick={handleConfirmRemove}
+                  disabled={removing}
+                >
+                  {removing ? "Removing..." : "Confirm Removal"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/client/src/components/RequesterTicketDetailScreen.tsx
+++ b/client/src/components/RequesterTicketDetailScreen.tsx
@@ -8,6 +8,13 @@ import {
   TicketDetail,
   AttachmentItem,
 } from "../api.js";
+import {
+  ALLOWED_ATTACHMENT_MIME_TYPES,
+  ALLOWED_ATTACHMENT_EXTENSIONS,
+  MAX_ATTACHMENT_SIZE_BYTES,
+  MAX_ACTIVE_ATTACHMENTS,
+  MAX_REMOVAL_REASON_LENGTH,
+} from "../constants.js";
 import { useRequester } from "../context/RequesterContext.js";
 
 interface RequesterTicketDetailScreenProps {
@@ -97,23 +104,21 @@ export const RequesterTicketDetailScreen: React.FC<RequesterTicketDetailScreenPr
     setUploadSuccess("");
 
     // Client-side Validation (BR-21, BR-22, BR-23)
-    const allowedTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"];
     const ext = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
-    const allowedExts = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
 
-    if (!allowedTypes.includes(file.type) && !allowedExts.includes(ext)) {
+    if (!ALLOWED_ATTACHMENT_MIME_TYPES.includes(file.type) && !ALLOWED_ATTACHMENT_EXTENSIONS.includes(ext)) {
       setUploadError("Only JPG, PNG, WEBP, and PDF files are allowed");
       e.target.value = "";
       return;
     }
 
-    if (file.size > 5 * 1024 * 1024) {
+    if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
       setUploadError("File exceeds the 5 MB limit");
       e.target.value = "";
       return;
     }
 
-    if (activeAttachments.length >= 5) {
+    if (activeAttachments.length >= MAX_ACTIVE_ATTACHMENTS) {
       setUploadError("A ticket may have at most 5 active attachments");
       e.target.value = "";
       return;
@@ -146,8 +151,14 @@ export const RequesterTicketDetailScreen: React.FC<RequesterTicketDetailScreenPr
   const handleConfirmRemove = async () => {
     if (!removeTarget || !selectedRequester) return;
 
-    if (!removeReason.trim()) {
+    const trimmed = removeReason.trim();
+    if (!trimmed) {
       setRemoveReasonError("A removal reason is required");
+      return;
+    }
+
+    if (trimmed.length > MAX_REMOVAL_REASON_LENGTH) {
+      setRemoveReasonError("Removal reason must not exceed 500 characters");
       return;
     }
 
@@ -432,6 +443,7 @@ export const RequesterTicketDetailScreen: React.FC<RequesterTicketDetailScreenPr
                     id="removeReasonInput"
                     className={`form-control form-control-sm ${removeReasonError ? "is-invalid" : ""}`}
                     rows={3}
+                    maxLength={MAX_REMOVAL_REASON_LENGTH}
                     placeholder="Enter reason for removing this attachment..."
                     value={removeReason}
                     onChange={(e) => setRemoveReason(e.target.value)}

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,0 +1,16 @@
+// BR-21: Allowed attachment file types, extensions, size limits, and count limits
+export const ALLOWED_ATTACHMENT_MIME_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+];
+
+export const ALLOWED_ATTACHMENT_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+
+export const MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export const MAX_ACTIVE_ATTACHMENTS = 5;
+
+export const MAX_REMOVAL_REASON_LENGTH = 500;

--- a/client/tests/lab-02/AttachmentSection.test.tsx
+++ b/client/tests/lab-02/AttachmentSection.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { RequesterTicketDetailScreen } from "../../src/components/RequesterTicketDetailScreen.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import * as api from "../../src/api.js";
+
+describe("AttachmentSection (UI-11, UI-12)", () => {
+  const mockRequester: api.RequesterUser = {
+    id: 1,
+    name: "Jennifer Anderson",
+    email: "jennifer.anderson@example.com",
+  };
+
+  const mockTicket: api.TicketDetail = {
+    id: 101,
+    ticketNumber: "TKT-2026-000042",
+    requesterId: 1,
+    categoryName: "Hardware",
+    relatedSystemName: "Corporate Laptop",
+    summary: "Laptop battery drains quickly",
+    description: "My laptop battery is draining much faster than usual.",
+    requestedPriority: "MEDIUM",
+    itPriority: null,
+    currentStatus: "NEW",
+    createdAt: "2026-08-20T09:14:00.000Z",
+    updatedAt: "2026-08-20T09:14:00.000Z",
+  };
+
+  const activeAttachment: api.AttachmentItem = {
+    id: 501,
+    fileName: "battery_report.pdf",
+    sizeBytes: 843211,
+    uploadedAt: "2026-08-20T09:16:00.000Z",
+    removedAt: null,
+    removedReason: null,
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+    sessionStorage.setItem("toktickit_selected_requester", JSON.stringify(mockRequester));
+    vi.spyOn(api, "getTicket").mockResolvedValue(mockTicket);
+  });
+
+  it("UI-11: soft-removes attachment in UI, displaying removed metadata and disabling download (AC-08)", async () => {
+    vi.spyOn(api, "getAttachments").mockResolvedValue([activeAttachment]);
+    vi.spyOn(api, "deleteAttachment").mockResolvedValue({
+      id: 501,
+      fileName: "battery_report.pdf",
+      removedAt: "2026-08-20T10:00:00.000Z",
+      removedReason: "Uploaded wrong document",
+    });
+
+    render(
+      <RequesterProvider>
+        <RequesterTicketDetailScreen ticketId={101} onBack={() => {}} />
+      </RequesterProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("battery_report.pdf")).toBeInTheDocument();
+    });
+
+    // Click Remove button
+    const removeBtn = screen.getByRole("button", { name: /Remove battery_report.pdf/i });
+    fireEvent.click(removeBtn);
+
+    // Enter reason and confirm
+    await waitFor(() => {
+      expect(screen.getByText(/Remove Attachment/i)).toBeInTheDocument();
+    });
+
+    const reasonInput = screen.getByPlaceholderText(/Enter reason for removing/i);
+    fireEvent.change(reasonInput, { target: { value: "Uploaded wrong document" } });
+
+    const confirmBtn = screen.getByRole("button", { name: /Confirm Removal/i });
+    fireEvent.click(confirmBtn);
+
+    // Expect attachment to show as removed badge with reason, and Download link removed
+    await waitFor(() => {
+      expect(screen.getByText(/Uploaded wrong document/i)).toBeInTheDocument();
+      expect(screen.getByText("Removed")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("link", { name: /Download battery_report.pdf/i })).not.toBeInTheDocument();
+  });
+
+  it("UI-12: rejects oversized file selection client-side before upload attempt (AC-06)", async () => {
+    vi.spyOn(api, "getAttachments").mockResolvedValue([]);
+    const uploadSpy = vi.spyOn(api, "uploadAttachment");
+
+    render(
+      <RequesterProvider>
+        <RequesterTicketDetailScreen ticketId={101} onBack={() => {}} />
+      </RequesterProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Attachments \(/i)).toBeInTheDocument();
+    });
+
+    // Create a 6MB dummy file
+    const oversizedFile = new File([new ArrayBuffer(6 * 1024 * 1024)], "large.pdf", {
+      type: "application/pdf",
+    });
+
+    const fileInput = screen.getByLabelText(/Upload Attachment/i);
+    fireEvent.change(fileInput, { target: { files: [oversizedFile] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/File exceeds the 5 MB limit/i)).toBeInTheDocument();
+    });
+
+    // Verify upload API was NOT called
+    expect(uploadSpy).not.toHaveBeenCalled();
+  });
+});

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { RequesterTicketDetailScreen } from "../../src/components/RequesterTicketDetailScreen.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import * as api from "../../src/api.js";
+
+describe("RequesterTicketDetailScreen (UI-10)", () => {
+  const mockRequester: api.RequesterUser = {
+    id: 1,
+    name: "Jennifer Anderson",
+    email: "jennifer.anderson@example.com",
+  };
+
+  const mockTicket: api.TicketDetail = {
+    id: 101,
+    ticketNumber: "TKT-2026-000042",
+    requesterId: 1,
+    categoryName: "Hardware",
+    relatedSystemName: "Corporate Laptop",
+    summary: "Laptop battery drains quickly",
+    description: "My laptop battery is draining much faster than usual during normal usage.",
+    requestedPriority: "MEDIUM",
+    itPriority: null,
+    currentStatus: "NEW",
+    createdAt: "2026-08-20T09:14:00.000Z",
+    updatedAt: "2026-08-20T09:14:00.000Z",
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+    sessionStorage.setItem("toktickit_selected_requester", JSON.stringify(mockRequester));
+    vi.spyOn(api, "getTicket").mockResolvedValue(mockTicket);
+    vi.spyOn(api, "getAttachments").mockResolvedValue([]);
+  });
+
+  it("UI-10: renders all ticket header fields as read-only without edit controls (FR-12, BR-30)", async () => {
+    render(
+      <RequesterProvider>
+        <RequesterTicketDetailScreen ticketId={101} onBack={() => {}} />
+      </RequesterProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Laptop battery drains quickly")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("TKT-2026-000042")[0]).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Corporate Laptop")).toBeInTheDocument();
+    expect(screen.getByText("Jennifer Anderson")).toBeInTheDocument();
+    expect(screen.getByText(/My laptop battery is draining much faster/i)).toBeInTheDocument();
+    expect(screen.getByText(/Not yet assigned/i)).toBeInTheDocument();
+
+    // Verify NO input/textarea/select edit controls exist for header fields
+    expect(screen.queryByRole("textbox", { name: /summary/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /description/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -149,9 +149,9 @@ sort, and pagination (BR-10 through BR-14).
 |---|---|---|---|
 | `search` | string | none | Matches ticketNumber (partial) or summary (case-insensitive partial) |
 | `categoryId` | number | none | Exact match filter |
-| `requestedPriority` | LOW\|MEDIUM\|HIGH | none | Exact match filter |
-| `itPriority` | LOW\|MEDIUM\|HIGH | none | Exact match filter |
-| `currentStatus` | string | none | Exact match filter |
+| `requestedPriority` | LOW\|MEDIUM\|HIGH | none | Exact match filter (invalid values return 400 Bad Request) |
+| `itPriority` | LOW\|MEDIUM\|HIGH | none | Exact match filter (invalid values return 400 Bad Request) |
+| `currentStatus` | string | none | Exact match filter; allowed enum: NEW (invalid values return 400 Bad Request) |
 | `sortBy` | createdAt\|ticketNumber | createdAt | Sort field |
 | `sortDir` | asc\|desc | desc | Sort direction |
 | `page` | number | 1 | 1-indexed |
@@ -187,6 +187,10 @@ sort, and pagination (BR-10 through BR-14).
 **Errors:**
 - 401 if `X-Requester-Id` header is missing; 400 if `X-Requester-Id` format is invalid or ID is inactive (see Section 12)
 - 400 for a genuinely malformed (non-numeric) `categoryId`
+- 400 if filter parameter (`requestedPriority`, `itPriority`, `currentStatus`) contains an invalid value:
+```json
+{ "error": "Invalid requestedPriority. Allowed values: LOW, MEDIUM, HIGH" }
+```
 - 500 for unexpected server failure. Out-of-range `page`/`pageSize` never errors (BR-14) — it clamps instead.
 
 ---

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -324,6 +324,7 @@ ticket ID belongs to a different Requester (AC-03).
 ```json
 { "reason": "Uploaded wrong file" }
 ```
+`reason` is required, trimmed, minimum 1 and maximum 500 characters (BR-32).
 
 **Response 200:**
 ```json
@@ -338,6 +339,7 @@ ticket ID belongs to a different Requester (AC-03).
 **Errors:**
 - 401 if `X-Requester-Id` header is missing; 400 if `X-Requester-Id` format is invalid or ID is inactive (see Section 12)
 - 400 missing reason — `{ "error": "A removal reason is required" }`
+- 400 reason exceeds 500 characters — `{ "error": "Removal reason must not exceed 500 characters" }`
 - 404 not found / not owned — `{ "error": "Attachment not found" }`
 - 409 already removed — `{ "error": "Attachment has already been removed" }`
 

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -144,6 +144,7 @@ manage their own tickets and attachments — never anyone else's.
 - BR-27: If Ticket creation succeeds but an attached file's upload fails, the Ticket
   is still saved; the user is informed which specific file(s) failed and may retry
   adding attachments afterward from Ticket Detail.
+- BR-32: Attachment removal reason is required, trimmed, minimum 1 and maximum 500 characters.
 
 ### Inactive Requesters
 - BR-28: An inactive Development Requester cannot be selected, and any ticket data

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
+        "@types/multer": "^2.2.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.3.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -935,7 +937,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -946,7 +947,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -980,7 +980,6 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -993,7 +992,6 @@
       "version": "4.19.9",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
       "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1006,7 +1004,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/methods": {
@@ -1020,14 +1017,21 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1037,21 +1041,18 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1061,7 +1062,6 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1073,7 +1073,6 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -1230,6 +1229,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1282,6 +1287,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1380,6 +1402,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2035,6 +2072,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2245,6 +2301,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2482,6 +2552,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2651,6 +2738,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2669,7 +2762,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -2680,6 +2772,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,11 +11,15 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "vitest run"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "@types/multer": "^2.2.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.3.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/prisma/migrations/20260906064518_add_attachment_model/migration.sql
+++ b/server/prisma/migrations/20260906064518_add_attachment_model/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "storedFileName" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removedReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_idx" ON "Attachment"("ticketId");
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -73,6 +73,26 @@ model Ticket {
   currentStatus     TicketStatus  @default(NEW)
   createdAt         DateTime      @default(now())
   updatedAt         DateTime      @updatedAt
+  attachments       Attachment[]
 
   @@index([requesterId])
+}
+
+// ---------------------------------------------------------------------------
+// Lab 2 Issue 5 — Attachment model
+// ---------------------------------------------------------------------------
+
+model Attachment {
+  id             Int       @id @default(autoincrement())
+  ticketId       Int
+  ticket         Ticket    @relation(fields: [ticketId], references: [id])
+  fileName       String
+  storedFileName String
+  mimeType       String
+  sizeBytes      Int
+  uploadedAt     DateTime  @default(now())
+  removedAt      DateTime?
+  removedReason  String?
+
+  @@index([ticketId])
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import crypto from "crypto";
 import multer from "multer";
 import { getPrisma } from "./prisma.js";
+import { AttachmentConstants } from "./constants.js";
 
 const uploadDir = path.resolve(process.cwd(), "uploads/attachments");
 if (!fs.existsSync(uploadDir)) {
@@ -471,26 +472,30 @@ app.get("/api/tickets/:id", async (req: Request, res: Response) => {
 });
 
 // 7. POST /api/tickets/:id/attachments -> Upload an Attachment to an owned Ticket (BR-21, BR-22, BR-23, BR-26)
-app.post("/api/tickets/:id/attachments", (req: Request, res: Response) => {
-  upload.single("file")(req, res, async (err: any) => {
-    const requesterId = await validateRequesterHeader(req, res);
-    if (requesterId === null) return;
+app.post("/api/tickets/:id/attachments", async (req: Request, res: Response) => {
+  // Pre-check 1: Validate Requester Header BEFORE multer parses or writes file to disk
+  const requesterId = await validateRequesterHeader(req, res);
+  if (requesterId === null) return;
 
-    const parsedTicketId = parseInt(req.params.id, 10);
-    if (isNaN(parsedTicketId)) {
-      res.status(404).json({ error: "Ticket not found" });
-      return;
-    }
+  const parsedTicketId = parseInt(req.params.id, 10);
+  if (isNaN(parsedTicketId)) {
+    res.status(404).json({ error: "Ticket not found" });
+    return;
+  }
+
+  // Pre-check 2: Validate Ticket Existence & Ownership BEFORE multer parses or writes file to disk
+  const prisma = getPrisma();
+  const preCheckTicket = await prisma.ticket.findUnique({ where: { id: parsedTicketId } });
+  if (!preCheckTicket || preCheckTicket.requesterId !== requesterId) {
+    res.status(404).json({ error: "Ticket not found" });
+    return;
+  }
+
+  // Proceed with multer upload middleware
+  upload.single("file")(req, res, async (err: any) => {
+    let success = false;
 
     try {
-      const prisma = getPrisma();
-      const ticket = await prisma.ticket.findUnique({ where: { id: parsedTicketId } });
-      if (!ticket || ticket.requesterId !== requesterId) {
-        if (req.file?.path && fs.existsSync(req.file.path)) fs.unlinkSync(req.file.path);
-        res.status(404).json({ error: "Ticket not found" });
-        return;
-      }
-
       const file = req.file;
       if (!file) {
         res.status(400).json({ error: "No file uploaded" });
@@ -498,43 +503,46 @@ app.post("/api/tickets/:id/attachments", (req: Request, res: Response) => {
       }
 
       // Validate type (BR-21): JPG/JPEG, PNG, WEBP, PDF
-      const allowedMimeTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"];
       const ext = path.extname(file.originalname).toLowerCase();
-      const allowedExts = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
-
-      if (!allowedMimeTypes.includes(file.mimetype) || !allowedExts.includes(ext)) {
-        if (file.path && fs.existsSync(file.path)) fs.unlinkSync(file.path);
+      if (
+        !AttachmentConstants.ALLOWED_MIME_TYPES.includes(file.mimetype) ||
+        !AttachmentConstants.ALLOWED_EXTENSIONS.includes(ext)
+      ) {
         res.status(400).json({ error: "Only JPG, PNG, WEBP, and PDF files are allowed" });
         return;
       }
 
       // Validate size (BR-22): 5MB
-      if (file.size > 5 * 1024 * 1024 || err?.code === "LIMIT_FILE_SIZE") {
-        if (file.path && fs.existsSync(file.path)) fs.unlinkSync(file.path);
+      if (file.size > AttachmentConstants.MAX_SIZE_BYTES || err?.code === "LIMIT_FILE_SIZE") {
         res.status(400).json({ error: "File exceeds the 5 MB limit" });
         return;
       }
 
-      // Validate count limit (BR-23): max 5 active attachments
-      const activeCount = await prisma.attachment.count({
-        where: { ticketId: parsedTicketId, removedAt: null },
+      // Atomic Transaction with Row Locking (SELECT FOR UPDATE) to prevent race conditions on BR-23 5-active limit
+      const attachment = await prisma.$transaction(async (tx) => {
+        // Acquire row lock on the ticket to serialize concurrent uploads for the same ticket
+        await tx.$executeRaw`SELECT id FROM "Ticket" WHERE id = ${parsedTicketId} FOR UPDATE`;
+
+        const activeCount = await tx.attachment.count({
+          where: { ticketId: parsedTicketId, removedAt: null },
+        });
+
+        if (activeCount >= AttachmentConstants.MAX_ACTIVE_ATTACHMENTS) {
+          throw new Error("A ticket may have at most 5 active attachments");
+        }
+
+        return await tx.attachment.create({
+          data: {
+            ticketId: parsedTicketId,
+            fileName: file.originalname,
+            storedFileName: file.filename,
+            mimeType: file.mimetype,
+            sizeBytes: file.size,
+          },
+        });
       });
 
-      if (activeCount >= 5) {
-        if (file.path && fs.existsSync(file.path)) fs.unlinkSync(file.path);
-        res.status(400).json({ error: "A ticket may have at most 5 active attachments" });
-        return;
-      }
-
-      const attachment = await prisma.attachment.create({
-        data: {
-          ticketId: parsedTicketId,
-          fileName: file.originalname,
-          storedFileName: file.filename,
-          mimeType: file.mimetype,
-          sizeBytes: file.size,
-        },
-      });
+      success = true;
 
       res.status(201).json({
         id: attachment.id,
@@ -545,9 +553,21 @@ app.post("/api/tickets/:id/attachments", (req: Request, res: Response) => {
         uploadedAt: attachment.uploadedAt.toISOString(),
         removedAt: null,
       });
-    } catch (error) {
-      if (req.file?.path && fs.existsSync(req.file.path)) fs.unlinkSync(req.file.path);
-      res.status(500).json({ error: "Unable to upload attachment" });
+    } catch (error: any) {
+      if (error?.message === "A ticket may have at most 5 active attachments") {
+        res.status(400).json({ error: error.message });
+      } else {
+        res.status(500).json({ error: "Unable to upload attachment" });
+      }
+    } finally {
+      // Safety net: If upload did not result in a successful 201 creation, guarantee file cleanup
+      if (!success && req.file?.path && fs.existsSync(req.file.path)) {
+        try {
+          fs.unlinkSync(req.file.path);
+        } catch {
+          // Ignore unlink errors if file was already removed
+        }
+      }
     }
   });
 });
@@ -640,8 +660,14 @@ app.delete("/api/attachments/:id", async (req: Request, res: Response) => {
   }
 
   const { reason } = req.body || {};
-  if (!reason || typeof reason !== "string" || reason.trim() === "") {
+  const trimmedReason = typeof reason === "string" ? reason.trim() : "";
+  if (!trimmedReason) {
     res.status(400).json({ error: "A removal reason is required" });
+    return;
+  }
+
+  if (trimmedReason.length > AttachmentConstants.MAX_REMOVAL_REASON_LENGTH) {
+    res.status(400).json({ error: "Removal reason must not exceed 500 characters" });
     return;
   }
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,32 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
+import path from "path";
+import fs from "fs";
+import crypto from "crypto";
+import multer from "multer";
 import { getPrisma } from "./prisma.js";
+
+const uploadDir = path.resolve(process.cwd(), "uploads/attachments");
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, uploadDir);
+  },
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const storedName = `${Date.now()}-${crypto.randomUUID()}${ext}`;
+    cb(null, storedName);
+  },
+});
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 10 * 1024 * 1024 },
+});
+
 // getPrisma() is your lazy database handle. Call it INSIDE a route when you
 // need the DB (Issue 4). It is intentionally unused until then.
 void getPrisma;
@@ -288,15 +314,30 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
   }
 
   // Priority filters
-  if (requestedPriority && typeof requestedPriority === "string") {
+  const validPriorities = ["LOW", "MEDIUM", "HIGH"];
+  if (requestedPriority !== undefined && requestedPriority !== "") {
+    if (typeof requestedPriority !== "string" || !validPriorities.includes(requestedPriority)) {
+      res.status(400).json({ error: "Invalid requestedPriority. Allowed values: LOW, MEDIUM, HIGH" });
+      return;
+    }
     whereClause.requestedPriority = requestedPriority;
   }
-  if (itPriority && typeof itPriority === "string") {
+
+  if (itPriority !== undefined && itPriority !== "") {
+    if (typeof itPriority !== "string" || !validPriorities.includes(itPriority)) {
+      res.status(400).json({ error: "Invalid itPriority. Allowed values: LOW, MEDIUM, HIGH" });
+      return;
+    }
     whereClause.itPriority = itPriority;
   }
 
   // Current status filter
-  if (currentStatus && typeof currentStatus === "string") {
+  const validStatuses = ["NEW"];
+  if (currentStatus !== undefined && currentStatus !== "") {
+    if (typeof currentStatus !== "string" || !validStatuses.includes(currentStatus)) {
+      res.status(400).json({ error: "Invalid currentStatus. Allowed values: NEW" });
+      return;
+    }
     whereClause.currentStatus = currentStatus;
   }
 
@@ -377,6 +418,266 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
     });
   } catch (error) {
     res.status(500).json({ error: "Unable to load tickets" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Lab 2 Issue 5 — Requester Ticket Detail & Attachments
+// ---------------------------------------------------------------------------
+
+// 6. GET /api/tickets/:id -> Retrieve one owned Ticket (BR-10, AC-03)
+app.get("/api/tickets/:id", async (req: Request, res: Response) => {
+  const requesterId = await validateRequesterHeader(req, res);
+  if (requesterId === null) return;
+
+  const parsedTicketId = parseInt(req.params.id, 10);
+  if (isNaN(parsedTicketId)) {
+    res.status(404).json({ error: "Ticket not found" });
+    return;
+  }
+
+  try {
+    const prisma = getPrisma();
+    const ticket = await prisma.ticket.findUnique({
+      where: { id: parsedTicketId },
+      include: {
+        category: { select: { name: true } },
+        relatedSystem: { select: { name: true } },
+      },
+    });
+
+    if (!ticket || ticket.requesterId !== requesterId) {
+      res.status(404).json({ error: "Ticket not found" });
+      return;
+    }
+
+    res.status(200).json({
+      id: ticket.id,
+      ticketNumber: ticket.ticketNumber,
+      requesterId: ticket.requesterId,
+      categoryName: ticket.category.name,
+      relatedSystemName: ticket.relatedSystem.name,
+      summary: ticket.summary,
+      description: ticket.description,
+      requestedPriority: ticket.requestedPriority,
+      itPriority: ticket.itPriority,
+      currentStatus: ticket.currentStatus,
+      createdAt: ticket.createdAt.toISOString(),
+      updatedAt: ticket.updatedAt.toISOString(),
+    });
+  } catch (error) {
+    res.status(500).json({ error: "Unable to load ticket details" });
+  }
+});
+
+// 7. POST /api/tickets/:id/attachments -> Upload an Attachment to an owned Ticket (BR-21, BR-22, BR-23, BR-26)
+app.post("/api/tickets/:id/attachments", (req: Request, res: Response) => {
+  upload.single("file")(req, res, async (err: any) => {
+    const requesterId = await validateRequesterHeader(req, res);
+    if (requesterId === null) return;
+
+    const parsedTicketId = parseInt(req.params.id, 10);
+    if (isNaN(parsedTicketId)) {
+      res.status(404).json({ error: "Ticket not found" });
+      return;
+    }
+
+    try {
+      const prisma = getPrisma();
+      const ticket = await prisma.ticket.findUnique({ where: { id: parsedTicketId } });
+      if (!ticket || ticket.requesterId !== requesterId) {
+        if (req.file?.path && fs.existsSync(req.file.path)) fs.unlinkSync(req.file.path);
+        res.status(404).json({ error: "Ticket not found" });
+        return;
+      }
+
+      const file = req.file;
+      if (!file) {
+        res.status(400).json({ error: "No file uploaded" });
+        return;
+      }
+
+      // Validate type (BR-21): JPG/JPEG, PNG, WEBP, PDF
+      const allowedMimeTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"];
+      const ext = path.extname(file.originalname).toLowerCase();
+      const allowedExts = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+
+      if (!allowedMimeTypes.includes(file.mimetype) || !allowedExts.includes(ext)) {
+        if (file.path && fs.existsSync(file.path)) fs.unlinkSync(file.path);
+        res.status(400).json({ error: "Only JPG, PNG, WEBP, and PDF files are allowed" });
+        return;
+      }
+
+      // Validate size (BR-22): 5MB
+      if (file.size > 5 * 1024 * 1024 || err?.code === "LIMIT_FILE_SIZE") {
+        if (file.path && fs.existsSync(file.path)) fs.unlinkSync(file.path);
+        res.status(400).json({ error: "File exceeds the 5 MB limit" });
+        return;
+      }
+
+      // Validate count limit (BR-23): max 5 active attachments
+      const activeCount = await prisma.attachment.count({
+        where: { ticketId: parsedTicketId, removedAt: null },
+      });
+
+      if (activeCount >= 5) {
+        if (file.path && fs.existsSync(file.path)) fs.unlinkSync(file.path);
+        res.status(400).json({ error: "A ticket may have at most 5 active attachments" });
+        return;
+      }
+
+      const attachment = await prisma.attachment.create({
+        data: {
+          ticketId: parsedTicketId,
+          fileName: file.originalname,
+          storedFileName: file.filename,
+          mimeType: file.mimetype,
+          sizeBytes: file.size,
+        },
+      });
+
+      res.status(201).json({
+        id: attachment.id,
+        ticketId: attachment.ticketId,
+        fileName: attachment.fileName,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.sizeBytes,
+        uploadedAt: attachment.uploadedAt.toISOString(),
+        removedAt: null,
+      });
+    } catch (error) {
+      if (req.file?.path && fs.existsSync(req.file.path)) fs.unlinkSync(req.file.path);
+      res.status(500).json({ error: "Unable to upload attachment" });
+    }
+  });
+});
+
+// 8. GET /api/tickets/:id/attachments -> List attachment metadata for an owned Ticket
+app.get("/api/tickets/:id/attachments", async (req: Request, res: Response) => {
+  const requesterId = await validateRequesterHeader(req, res);
+  if (requesterId === null) return;
+
+  const parsedTicketId = parseInt(req.params.id, 10);
+  if (isNaN(parsedTicketId)) {
+    res.status(404).json({ error: "Ticket not found" });
+    return;
+  }
+
+  try {
+    const prisma = getPrisma();
+    const ticket = await prisma.ticket.findUnique({ where: { id: parsedTicketId } });
+    if (!ticket || ticket.requesterId !== requesterId) {
+      res.status(404).json({ error: "Ticket not found" });
+      return;
+    }
+
+    const attachments = await prisma.attachment.findMany({
+      where: { ticketId: parsedTicketId },
+      orderBy: { uploadedAt: "asc" },
+    });
+
+    const result = attachments.map((att) => ({
+      id: att.id,
+      fileName: att.fileName,
+      sizeBytes: att.sizeBytes,
+      uploadedAt: att.uploadedAt.toISOString(),
+      removedAt: att.removedAt ? att.removedAt.toISOString() : null,
+      removedReason: att.removedReason,
+    }));
+
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(500).json({ error: "Unable to load attachments" });
+  }
+});
+
+// 9. GET /api/attachments/:id/download -> Download an active, owned Attachment (BR-25)
+app.get("/api/attachments/:id/download", async (req: Request, res: Response) => {
+  const requesterId = await validateRequesterHeader(req, res);
+  if (requesterId === null) return;
+
+  const parsedAttachmentId = parseInt(req.params.id, 10);
+  if (isNaN(parsedAttachmentId)) {
+    res.status(404).json({ error: "Attachment not found" });
+    return;
+  }
+
+  try {
+    const prisma = getPrisma();
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: parsedAttachmentId },
+      include: { ticket: true },
+    });
+
+    if (!attachment || attachment.ticket.requesterId !== requesterId || attachment.removedAt !== null) {
+      res.status(404).json({ error: "Attachment not found" });
+      return;
+    }
+
+    const filePath = path.join(uploadDir, attachment.storedFileName);
+    if (!fs.existsSync(filePath)) {
+      res.status(404).json({ error: "Attachment not found" });
+      return;
+    }
+
+    res.setHeader("Content-Type", attachment.mimeType);
+    res.setHeader("Content-Disposition", `attachment; filename="${encodeURIComponent(attachment.fileName)}"`);
+    res.sendFile(filePath);
+  } catch (error) {
+    res.status(500).json({ error: "Unable to download attachment" });
+  }
+});
+
+// 10. DELETE /api/attachments/:id -> Soft-remove an owned Attachment (BR-24, BR-26)
+app.delete("/api/attachments/:id", async (req: Request, res: Response) => {
+  const requesterId = await validateRequesterHeader(req, res);
+  if (requesterId === null) return;
+
+  const parsedAttachmentId = parseInt(req.params.id, 10);
+  if (isNaN(parsedAttachmentId)) {
+    res.status(404).json({ error: "Attachment not found" });
+    return;
+  }
+
+  const { reason } = req.body || {};
+  if (!reason || typeof reason !== "string" || reason.trim() === "") {
+    res.status(400).json({ error: "A removal reason is required" });
+    return;
+  }
+
+  try {
+    const prisma = getPrisma();
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: parsedAttachmentId },
+      include: { ticket: true },
+    });
+
+    if (!attachment || attachment.ticket.requesterId !== requesterId) {
+      res.status(404).json({ error: "Attachment not found" });
+      return;
+    }
+
+    if (attachment.removedAt !== null) {
+      res.status(409).json({ error: "Attachment has already been removed" });
+      return;
+    }
+
+    const updated = await prisma.attachment.update({
+      where: { id: parsedAttachmentId },
+      data: {
+        removedAt: new Date(),
+        removedReason: reason.trim(),
+      },
+    });
+
+    res.status(200).json({
+      id: updated.id,
+      fileName: updated.fileName,
+      removedAt: updated.removedAt!.toISOString(),
+      removedReason: updated.removedReason,
+    });
+  } catch (error) {
+    res.status(500).json({ error: "Unable to remove attachment" });
   }
 });
 

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -1,0 +1,18 @@
+// BR-21: Allowed attachment file types, extensions, size limits, and count limits
+export class AttachmentConstants {
+  static readonly ALLOWED_MIME_TYPES = [
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/webp",
+    "application/pdf",
+  ];
+
+  static readonly ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+
+  static readonly MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+  static readonly MAX_ACTIVE_ATTACHMENTS = 5;
+
+  static readonly MAX_REMOVAL_REASON_LENGTH = 500;
+}

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+import path from "path";
+import fs from "fs";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+
+describe("Attachment API (API-10 through API-15)", () => {
+  const prisma = getPrisma();
+  let ticket1Id: number;
+  let ticket2Id: number;
+
+  beforeEach(async () => {
+    await prisma.attachment.deleteMany({ where: { ticket: { requesterId: { in: [1, 2] } } } });
+    await prisma.ticket.deleteMany({ where: { requesterId: { in: [1, 2] } } });
+
+    const prefix = `TKT-ATT-${Date.now()}`;
+
+    const t1 = await prisma.ticket.create({
+      data: {
+        ticketNumber: `${prefix}-001`,
+        requesterId: 1,
+        categoryId: 1,
+        relatedSystemId: 1,
+        summary: "Attachment test ticket for Requester 1",
+        description: "Description for attachment test.",
+        requestedPriority: "MEDIUM",
+        currentStatus: "NEW",
+      },
+    });
+
+    const t2 = await prisma.ticket.create({
+      data: {
+        ticketNumber: `${prefix}-002`,
+        requesterId: 2,
+        categoryId: 1,
+        relatedSystemId: 1,
+        summary: "Attachment test ticket for Requester 2",
+        description: "Description for attachment test 2.",
+        requestedPriority: "LOW",
+        currentStatus: "NEW",
+      },
+    });
+
+    ticket1Id = t1.id;
+    ticket2Id = t2.id;
+  });
+
+  afterEach(async () => {
+    await prisma.attachment.deleteMany({ where: { ticketId: { in: [ticket1Id, ticket2Id] } } });
+    await prisma.ticket.deleteMany({ where: { id: { in: [ticket1Id, ticket2Id] } } });
+  });
+
+  it("API-10: uploads valid JPG under 5MB (AC-05, BR-21)", async () => {
+    const res = await request(app)
+      .post(`/api/tickets/${ticket1Id}/attachments`)
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.from("fake-jpg-content"), "test-image.jpg");
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("id");
+    expect(res.body.fileName).toBe("test-image.jpg");
+    expect(res.body.removedAt).toBeNull();
+  });
+
+  it("API-11: rejects 6MB file with size error (AC-06, BR-22)", async () => {
+    const largeBuffer = Buffer.alloc(6 * 1024 * 1024);
+    const res = await request(app)
+      .post(`/api/tickets/${ticket1Id}/attachments`)
+      .set("X-Requester-Id", "1")
+      .attach("file", largeBuffer, "large.pdf");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/exceeds the 5 MB limit/i);
+  });
+
+  it("API-12: rejects unsupported file type .docx (BR-21)", async () => {
+    const res = await request(app)
+      .post(`/api/tickets/${ticket1Id}/attachments`)
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.from("docx-content"), "document.docx");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Only JPG, PNG, WEBP, and PDF files are allowed/i);
+  });
+
+  it("API-13: rejects 6th active attachment when 5 active attachments exist (AC-07, BR-23)", async () => {
+    for (let i = 1; i <= 5; i++) {
+      await prisma.attachment.create({
+        data: {
+          ticketId: ticket1Id,
+          fileName: `file${i}.png`,
+          storedFileName: `stored_${i}.png`,
+          mimeType: "image/png",
+          sizeBytes: 100,
+        },
+      });
+    }
+
+    const res = await request(app)
+      .post(`/api/tickets/${ticket1Id}/attachments`)
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.from("image6-content"), "file6.png");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/at most 5 active attachments/i);
+  });
+
+  it("API-14: soft-removes an attachment and blocks download (AC-08, BR-24, BR-25)", async () => {
+    const att = await prisma.attachment.create({
+      data: {
+        ticketId: ticket1Id,
+        fileName: "to-remove.pdf",
+        storedFileName: "stored_to_remove.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 200,
+      },
+    });
+
+    const deleteRes = await request(app)
+      .delete(`/api/attachments/${att.id}`)
+      .set("X-Requester-Id", "1")
+      .send({ reason: "Uploaded wrong document" });
+
+    expect(deleteRes.status).toBe(200);
+    expect(deleteRes.body.id).toBe(att.id);
+    expect(deleteRes.body.removedAt).toBeDefined();
+    expect(deleteRes.body.removedReason).toBe("Uploaded wrong document");
+
+    // List attachments should still show metadata
+    const listRes = await request(app)
+      .get(`/api/tickets/${ticket1Id}/attachments`)
+      .set("X-Requester-Id", "1");
+
+    expect(listRes.status).toBe(200);
+    const removedItem = listRes.body.find((a: any) => a.id === att.id);
+    expect(removedItem).toBeDefined();
+    expect(removedItem.removedAt).not.toBeNull();
+    expect(removedItem.removedReason).toBe("Uploaded wrong document");
+
+    // Download attempt on soft-removed attachment must return 404 (BR-25)
+    const downloadRes = await request(app)
+      .get(`/api/attachments/${att.id}/download`)
+      .set("X-Requester-Id", "1");
+
+    expect(downloadRes.status).toBe(404);
+    expect(downloadRes.body.error).toBe("Attachment not found");
+  });
+
+  it("API-15: rejects soft-remove of an attachment belonging to another requester (BR-26)", async () => {
+    const att2 = await prisma.attachment.create({
+      data: {
+        ticketId: ticket2Id,
+        fileName: "requester2-file.png",
+        storedFileName: "stored_req2.png",
+        mimeType: "image/png",
+        sizeBytes: 150,
+      },
+    });
+
+    const deleteRes = await request(app)
+      .delete(`/api/attachments/${att2.id}`)
+      .set("X-Requester-Id", "1")
+      .send({ reason: "Trying to remove other requester file" });
+
+    expect(deleteRes.status).toBe(404);
+    expect(deleteRes.body.error).toBe("Attachment not found");
+  });
+});

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -166,4 +166,76 @@ describe("Attachment API (API-10 through API-15)", () => {
     expect(deleteRes.status).toBe(404);
     expect(deleteRes.body.error).toBe("Attachment not found");
   });
+
+  it("cleans up uploaded disk file when ownership check or validation fails", async () => {
+    const uploadDir = path.resolve(process.cwd(), "uploads/attachments");
+    const initialFiles = fs.existsSync(uploadDir) ? fs.readdirSync(uploadDir) : [];
+
+    // Attempt upload to ticket owned by Requester 2 using Requester 1 header
+    const res = await request(app)
+      .post(`/api/tickets/${ticket2Id}/attachments`)
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.from("unowned-file-content"), "unowned.png");
+
+    expect(res.status).toBe(404);
+
+    const currentFiles = fs.existsSync(uploadDir) ? fs.readdirSync(uploadDir) : [];
+    expect(currentFiles.length).toBe(initialFiles.length);
+  });
+
+  it("handles 2 concurrent upload requests atomically when 4 active attachments exist (race condition test)", async () => {
+    for (let i = 1; i <= 4; i++) {
+      await prisma.attachment.create({
+        data: {
+          ticketId: ticket1Id,
+          fileName: `file${i}.png`,
+          storedFileName: `stored_${i}.png`,
+          mimeType: "image/png",
+          sizeBytes: 100,
+        },
+      });
+    }
+
+    const req1 = request(app)
+      .post(`/api/tickets/${ticket1Id}/attachments`)
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.from("concurrent-file-1"), "concurrent1.png");
+
+    const req2 = request(app)
+      .post(`/api/tickets/${ticket1Id}/attachments`)
+      .set("X-Requester-Id", "1")
+      .attach("file", Buffer.from("concurrent-file-2"), "concurrent2.png");
+
+    const [res1, res2] = await Promise.all([req1, req2]);
+    const statuses = [res1.status, res2.status].sort();
+
+    // Exactly one should succeed (201) and one should be rejected (400)
+    expect(statuses).toEqual([201, 400]);
+
+    const activeCount = await prisma.attachment.count({
+      where: { ticketId: ticket1Id, removedAt: null },
+    });
+    expect(activeCount).toBe(5);
+  });
+
+  it("returns 400 when removalReason exceeds 500 characters (BR-32)", async () => {
+    const att = await prisma.attachment.create({
+      data: {
+        ticketId: ticket1Id,
+        fileName: "long-reason.pdf",
+        storedFileName: "stored_long_reason.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 200,
+      },
+    });
+
+    const longReason = "a".repeat(501);
+    const res = await request(app)
+      .delete(`/api/attachments/${att.id}`)
+      .set("X-Requester-Id", "1")
+      .send({ reason: longReason });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/must not exceed 500 characters/i);
+  });
 });

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -115,4 +115,34 @@ describe("GET /api/tickets (My Tickets API)", () => {
     expect(res.body.pagination.page).toBe(1);
     expect(res.body.pagination.pageSize).toBe(10);
   });
+
+  it("returns 400 when requestedPriority query parameter is invalid", async () => {
+    const res = await request(app)
+      .get("/api/tickets?requestedPriority=INVALID")
+      .set("X-Requester-Id", "3");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+    expect(res.body.error).toMatch(/Invalid requestedPriority/i);
+  });
+
+  it("returns 400 when currentStatus query parameter is invalid", async () => {
+    const res = await request(app)
+      .get("/api/tickets?currentStatus=NOT_A_REAL_STATUS")
+      .set("X-Requester-Id", "3");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+    expect(res.body.error).toMatch(/Invalid currentStatus/i);
+  });
+
+  it("filters tickets correctly when valid requestedPriority is supplied (regression check)", async () => {
+    const res = await request(app)
+      .get("/api/tickets?requestedPriority=HIGH")
+      .set("X-Requester-Id", "3");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].summary).toBe("Laptop battery issues");
+  });
 });

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+
+describe("GET /api/tickets/:id (Ticket Detail API)", () => {
+  const prisma = getPrisma();
+  let ticket1Id: number;
+  let ticket2Id: number;
+
+  beforeEach(async () => {
+    await prisma.ticket.deleteMany({ where: { requesterId: { in: [1, 2] } } });
+    const prefix = `TKT-DETAIL-${Date.now()}`;
+
+    const t1 = await prisma.ticket.create({
+      data: {
+        ticketNumber: `${prefix}-001`,
+        requesterId: 1,
+        categoryId: 1,
+        relatedSystemId: 1,
+        summary: "Requester 1 ticket for detail test",
+        description: "Detailed description for ticket 1.",
+        requestedPriority: "HIGH",
+        currentStatus: "NEW",
+      },
+    });
+
+    const t2 = await prisma.ticket.create({
+      data: {
+        ticketNumber: `${prefix}-002`,
+        requesterId: 2,
+        categoryId: 2,
+        relatedSystemId: 1,
+        summary: "Requester 2 ticket for detail test",
+        description: "Detailed description for ticket 2.",
+        requestedPriority: "LOW",
+        currentStatus: "NEW",
+      },
+    });
+
+    ticket1Id = t1.id;
+    ticket2Id = t2.id;
+  });
+
+  afterEach(async () => {
+    await prisma.ticket.deleteMany({ where: { id: { in: [ticket1Id, ticket2Id] } } });
+  });
+
+  it("returns ticket details for valid owned ticket", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${ticket1Id}`)
+      .set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(ticket1Id);
+    expect(res.body.summary).toBe("Requester 1 ticket for detail test");
+    expect(res.body.requesterId).toBe(1);
+    expect(res.body.categoryName).toBeDefined();
+    expect(res.body.relatedSystemName).toBeDefined();
+  });
+
+  it("API-05: returns generic 404 Not Found for ticket owned by another requester (AC-03, BR-10)", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${ticket2Id}`)
+      .set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Ticket not found" });
+  });
+
+  it("returns 404 for non-existent ticket ID", async () => {
+    const res = await request(app)
+      .get("/api/tickets/999999")
+      .set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Ticket not found" });
+  });
+});

--- a/server/uploads/attachments/1788677216229-265ecbd2-a3f9-4b99-a6c9-bd50261311f6.jpg
+++ b/server/uploads/attachments/1788677216229-265ecbd2-a3f9-4b99-a6c9-bd50261311f6.jpg
@@ -1,0 +1,1 @@
+fake-jpg-content

--- a/server/uploads/attachments/1788677355193-d98faf1c-e0c2-4c3a-89d1-a5d94358253a.jpg
+++ b/server/uploads/attachments/1788677355193-d98faf1c-e0c2-4c3a-89d1-a5d94358253a.jpg
@@ -1,0 +1,1 @@
+fake-jpg-content

--- a/server/uploads/attachments/1788679347201-d8d70c06-465d-4280-98f7-769c1b32de64.jpg
+++ b/server/uploads/attachments/1788679347201-d8d70c06-465d-4280-98f7-769c1b32de64.jpg
@@ -1,0 +1,1 @@
+fake-jpg-content

--- a/server/uploads/attachments/1788679347655-9618cb7d-8789-4df1-a063-6ae368718a23.png
+++ b/server/uploads/attachments/1788679347655-9618cb7d-8789-4df1-a063-6ae368718a23.png
@@ -1,0 +1,1 @@
+concurrent-file-1

--- a/server/uploads/attachments/1788679501824-3c418103-9cee-414f-a3f5-6102701eca92.jpg
+++ b/server/uploads/attachments/1788679501824-3c418103-9cee-414f-a3f5-6102701eca92.jpg
@@ -1,0 +1,1 @@
+fake-jpg-content

--- a/server/uploads/attachments/1788679502175-54f046ae-44f5-41c6-b69d-230edd78dbb4.png
+++ b/server/uploads/attachments/1788679502175-54f046ae-44f5-41c6-b69d-230edd78dbb4.png
@@ -1,0 +1,1 @@
+concurrent-file-1


### PR DESCRIPTION
Implement the read-only Ticket Detail screen and the full Attachment lifecycle (add, list, download, soft-remove) with ownership enforcement.

Acceptance Criteria
 Attachment Prisma model created per specification.md section 7.
 GET /api/tickets/:id enforces ownership (BR-10); cross-Requester access returns not-found (AC-03).
 POST /api/tickets/:id/attachments enforces type (BR-21), size (BR-22), and count (BR-23) limits.
 GET /api/attachments/:id/download blocks download of removed Attachments (BR-25).
 DELETE /api/attachments/:id performs soft removal only, retaining metadata (BR-24) and requiring a removal reason.
 Only the owning Requester may add/remove attachments (BR-26).
 Partial-failure handling implemented: Ticket saved even if an attachment upload fails, with a clear per-file error (BR-27).
 Requester Ticket Detail UI implemented per ui-spec.md: read-only header, separate Attachments section with active/removed/uploading states.
 AC-03, AC-05, AC-06, AC-07, AC-08 covered by passing automated tests.
 Unit + API + UI tests pass for this Issue's scope.